### PR TITLE
👷 Upload test report to codecov

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,9 +47,6 @@ jobs:
 
       - name: "Run tests"
         uses: pavelzw/pytest-action@v2.2.0
-        with:
-          report-title: >-
-            Pytest - Python ${{ matrix.PYTHON_VERSION }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.5.0
@@ -61,3 +58,14 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Test reporter
+        uses: phoenix-actions/test-reporting@v15
+        if: always()
+        with:
+          name: EsXport tests for (Python ${{ matrix.PYTHON_VERSION }})
+          path: junit.xml
+          reporter: java-junit
+          output-to: step-summary
+          only-summary: true
+          max-annotations: 0


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI workflow to remove the report title configuration from the pytest action and add a new step to upload test reports using the phoenix-actions/test-reporting action.

CI:
- Remove the report title configuration from the pytest action in the CI workflow.
- Add a new step to the CI workflow to upload test reports using the phoenix-actions/test-reporting action.

<!-- Generated by sourcery-ai[bot]: end summary -->