### PR TITLE
⬆️ Python 3.13 support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,12 +26,13 @@ jobs:
           - { PYTHON_VERSION: '3.10' }
           - { PYTHON_VERSION: '3.11' }
           - { PYTHON_VERSION: '3.12' }
+          - { PYTHON_VERSION: '3.13' }
     steps:
       - name: "Checkout to repository"
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
 
       - name: "Setup Python"
-        uses: actions/setup-python@v5.1.1
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           cache: 'pip'
@@ -55,7 +56,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1.0.0
+        uses: codecov/test-results-action@v1.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add Python 3.13 to the testing matrix in the GitHub Actions workflow.