### PR TITLE
🧪 Raise exception when no data is found

### DIFF
--- a/esxport/esxport.py
+++ b/esxport/esxport.py
@@ -21,6 +21,7 @@ from .exceptions import (
     IndexNotFoundError,
     InvalidEsQueryError,
     MetaFieldNotFoundError,
+    NoDataFoundError,
     ScrollExpiredError,
 )
 from .strings import (
@@ -185,8 +186,10 @@ class EsXport(object):
 
         logger.info(f"Found {self.num_results} results.")
 
-        if self.num_results > 0:
-            self._write_to_temp_file(res)
+        if self.num_results == 0:
+            msg = "No Data found in index."
+            raise NoDataFoundError(msg)
+        self._write_to_temp_file(res)
 
     def _flush_to_file(self: Self, hit_list: list[dict[str, Any]]) -> None:
         """Flush the search results to a temporary file."""

--- a/esxport/exceptions.py
+++ b/esxport/exceptions.py
@@ -31,3 +31,7 @@ class HealthCheckError(EsXportError):
 
 class InvalidEsQueryError(EsXportError):
     """Invalid query param."""
+
+
+class NoDataFoundError(EsXportError):
+    """No data found in the index."""


### PR DESCRIPTION
## Summary by Sourcery

Modify the search query functionality to raise an exception when no data is found in the Elasticsearch index

New Features:
- Introduce a new NoDataFoundError exception to handle cases with zero search results

Bug Fixes:
- Fix typos in test method names from 'flused' to 'flushed'

Enhancements:
- Improve error handling in search and export methods to explicitly handle scenarios with no data

Tests:
- Add test cases to verify the new NoDataFoundError exception is raised correctly
- Update existing test methods to check for the new error handling behavior