### PR TITLE
Handle HTTP

### DIFF
--- a/test/elastic/client_test.py
+++ b/test/elastic/client_test.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
 
 import pytest
 from elastic_transport import ObjectApiResponse
 
+from esxport.click_opt.cli_options import CliOptions
+from esxport.elastic import ElasticsearchClient
 from esxport.exceptions import ScrollExpiredError
 
 if TYPE_CHECKING:
     from typing_extensions import Self
-
-    from esxport.elastic import ElasticsearchClient
 
 
 class TestElasticsearchClient:
@@ -81,3 +82,54 @@ class TestElasticsearchClient:
         assert "cluster_name" in response_dict, "Cluster name should be present in the ping response."
         assert "version" in response_dict, "Elasticsearch version should be present in the ping response."
         assert "tagline" in response_dict, "Tagline should be present in the ping response."
+
+    @patch("esxport.elastic.elasticsearch.Elasticsearch")
+    @pytest.mark.parametrize(
+        ("url", "tls_expected"),
+        [
+            ("https://example.com:9200", True),
+            ("http://example.com:9200", False),
+            ("HTTPS://example.com:9200", True),  # Test uppercase scheme
+            ("HTTP://example.com:9200", False),  # Test uppercase scheme
+        ],
+    )
+    def test_url_scheme_handles_tls_options(
+        self: Self,
+        mock_elasticsearch: Mock,
+        url: str,
+        tls_expected: bool,  # noqa: FBT001
+    ) -> None:
+        """Test that TLS options are passed only for HTTPS URLs."""
+        cli_options = CliOptions(
+            {
+                "query": {"query": {"match_all": {}}},
+                "output_file": "test.csv",
+                "url": url,
+                "user": "test_user",
+                "password": "test_password",
+                "index_prefixes": ["test_index"],
+                "verify_certs": True,
+                "ca_certs": "/path/to/ca.crt",
+                "client_cert": "/path/to/client.crt",
+                "client_key": "/path/to/client.key",
+            },
+        )
+
+        ElasticsearchClient(cli_options)
+
+        mock_elasticsearch.assert_called_once()
+        call_kwargs = mock_elasticsearch.call_args.kwargs
+
+        assert call_kwargs["hosts"] == [url]
+        assert call_kwargs["basic_auth"] == ("test_user", "test_password")
+
+        if tls_expected:
+            assert call_kwargs["verify_certs"] is True
+            assert call_kwargs["ca_certs"] == "/path/to/ca.crt"
+            assert call_kwargs["client_cert"] == "/path/to/client.crt"
+            assert call_kwargs["client_key"] == "/path/to/client.key"
+        else:
+            assert "verify_certs" not in call_kwargs
+            assert "ca_certs" not in call_kwargs
+            assert "client_cert" not in call_kwargs
+            assert "client_key" not in call_kwargs


### PR DESCRIPTION
Fixes #94

## Summary by Sourcery

Ensure TLS options are only passed to ElasticsearchClient when using HTTPS URLs

Bug Fixes:
- Omit TLS verification and certificate parameters for HTTP endpoints in ElasticsearchClient initialization

Tests:
- Add tests to verify TLS options are applied for HTTPS URLs
- Add tests to verify TLS options are excluded for HTTP URLs